### PR TITLE
Specify __init__.py imports

### DIFF
--- a/kinase_focused_fragment_library/__init__.py
+++ b/kinase_focused_fragment_library/__init__.py
@@ -4,7 +4,6 @@ Subpocket-based fragmentation of kinase inhibitors
 """
 
 # Add imports here
-from .kinase_focused_fragment_library import *
 from . import preprocessing
 from . import fragmentation
 from . import recombination

--- a/kinase_focused_fragment_library/fragmentation/__init__.py
+++ b/kinase_focused_fragment_library/fragmentation/__init__.py
@@ -4,8 +4,4 @@ Subpocket-based fragmentation of kinase inhibitors
 """
 
 # Add imports of sub-modules here
-from .classes import *
-from .fragmentation import *
-from .pocketIdentification import *
-from .visualization import *
-from .cli import *
+from .cli import main

--- a/kinase_focused_fragment_library/preprocessing/__init__.py
+++ b/kinase_focused_fragment_library/preprocessing/__init__.py
@@ -4,6 +4,4 @@ Subpocket-based fragmentation of kinase inhibitors
 """
 
 # Add imports of sub-modules here
-from .discard import *
-from .preprocessing import *
-from .cli import *
+from .cli import main

--- a/kinase_focused_fragment_library/recombination/__init__.py
+++ b/kinase_focused_fragment_library/recombination/__init__.py
@@ -4,10 +4,4 @@ Subpocket-based fragmentation of kinase inhibitors
 """
 
 # Add imports of sub-modules here
-from .brics_rules import *
-from .classes_meta import *
-from .get_tuple import *
-from .pickle_loader import *
-from .process_queue import *
-from .process_results import *
-from .cli import *
+from .cli import main


### PR DESCRIPTION
## Description
Paula's package in its current form will only be used via the CLI, thus adapt `__init__.py` imports (=remove not needed imports). Thus, keep only `from cli import main` in `__init__.py` files.

See issue #15 for more details.

```bash
# kinase_focused_fragment_library/__init__.py
from . import preprocessing
from . import fragmentation
from . import recombination
```

```bash
# kinase_focused_fragment_library/preprocessing/__init__.py
from .cli import main
```

```bash
# kinase_focused_fragment_library/fragmentation/__init__.py
from .cli import main
```

```bash
# kinase_focused_fragment_library/recombination/__init__.py
from .cli import main
```

## Status
- [x] Ready to go