### PR TITLE
Rerun code base with new data and new use cases

### DIFF
--- a/kinase_focused_fragment_library/fragmentation/cli.py
+++ b/kinase_focused_fragment_library/fragmentation/cli.py
@@ -47,7 +47,7 @@ def main():
     subpocket_connections = {}
 
     # output file with metadata of discarded structures
-    discarded_structures = pd.DataFrame()
+    discarded_structures = []
 
     # ============================= INPUT AND OUTPUT ===============================================
 
@@ -106,7 +106,7 @@ def main():
                 print('ERROR in ' + folder + ':')
                 print('Ligand consists of multiple molecules.\n')
                 entry['violation'] = 'Multiple ligands present'
-                discarded_structures = discarded_structures.append(entry, ignore_index=True)
+                discarded_structures.append(entry)
                 continue
 
         lenLigand = ligand.GetNumAtoms()
@@ -137,7 +137,7 @@ def main():
         if skipStructure:
             count_missing_res += 1
             entry['violation'] = 'Missing residues'
-            discarded_structures = discarded_structures.append(entry, ignore_index=True)
+            discarded_structures.append(entry)
             continue
 
         # visualize subpocket centers using PyMOL
@@ -172,7 +172,7 @@ def main():
         if skipStructure:
             count_large_brics += 1
             entry['violation'] = 'Large BRICS fragment'
-            discarded_structures = discarded_structures.append(entry, ignore_index=True)
+            discarded_structures.append(entry)
             continue
 
         # Adjust subpocket assignments in order to keep small fragments uncleaved
@@ -217,7 +217,7 @@ def main():
         if AP not in [fragment.subpocket for fragment in fragments]:
             count_not_ap += 1
             entry['violation'] = 'AP not occupied'
-            discarded_structures = discarded_structures.append(entry, ignore_index=True)
+            discarded_structures.append(entry)
             continue
 
         # check for FP-BP connections
@@ -274,7 +274,7 @@ def main():
         if skipStructure:
             count_unwanted_subpocket_connections += 1
             entry['violation'] = 'Unwanted subpocket connection'
-            discarded_structures = discarded_structures.append(entry, ignore_index=True)
+            discarded_structures.append(entry)
             continue
 
         # store all occurring subpocket connections
@@ -363,6 +363,7 @@ def main():
     folderName = Path(args.fragmentlibrary) / 'discarded_ligands'
     if not folderName.exists():
         Path.mkdir(folderName)
+    discarded_structures = pd.DataFrame(discarded_structures).reset_index(drop=True)
     discarded_structures.to_csv(folderName / 'fragmentation.csv')
 
 

--- a/kinase_focused_fragment_library/preprocessing/cli.py
+++ b/kinase_focused_fragment_library/preprocessing/cli.py
@@ -84,6 +84,17 @@ def main():
         # ==================== FILTER UNLOADBALE STRUCTURES =======================================
 
         # load ligand and binding pocket to rdkit molecules
+        try:
+            ligand = Chem.MolFromMol2File(str(path_to_data / folder / 'ligand.mol2'), removeHs=False)
+            pocket = Chem.MolFromMol2File(str(path_to_data / folder / 'pocket.mol2'), removeHs=False)
+        except OSError:
+            print('ERROR in ' + folder + ':')
+            print('Ligand or pocket file '+entry.pdb_id+' ('+folder+') could not be loaded. \n')
+            count_ligand_errors += 1
+            filtered_data = filtered_data.drop(index)
+            entry['violation'] = 'Unloadable ligand or pocket file'
+            discarded_structures.append(entry)
+            continue
 
         # check if KLIFS ligand and protein are loadable with RDKit
         try:

--- a/kinase_focused_fragment_library/preprocessing/cli.py
+++ b/kinase_focused_fragment_library/preprocessing/cli.py
@@ -62,7 +62,7 @@ def main():
     filtered_data = KLIFSData.copy()
 
     # output file with metadata of discarded structures
-    discarded_structures = pd.DataFrame()
+    discarded_structures = []
 
     # =========================== ITERATE OVER STRUCTURES =========================================
 
@@ -78,14 +78,12 @@ def main():
             filtered_data = filtered_data.drop(index)
             count_substrates += 1
             entry['violation'] = 'Substrate'
-            discarded_structures = discarded_structures.append(entry, ignore_index=True)
+            discarded_structures.append(entry)
             continue
 
         # ==================== FILTER UNLOADBALE STRUCTURES =======================================
 
         # load ligand and binding pocket to rdkit molecules
-        ligand = Chem.MolFromMol2File(str(path_to_data / folder / 'ligand.mol2'), removeHs=False)
-        pocket = Chem.MolFromMol2File(str(path_to_data / folder / 'pocket.mol2'), removeHs=False)
 
         # check if KLIFS ligand and protein are loadable with RDKit
         try:
@@ -96,7 +94,7 @@ def main():
             count_ligand_errors += 1
             filtered_data = filtered_data.drop(index)
             entry['violation'] = 'Unloadable ligand'
-            discarded_structures = discarded_structures.append(entry, ignore_index=True)
+            discarded_structures.append(entry)
             continue
         try:
             pocketConf = pocket.GetConformer()
@@ -106,7 +104,7 @@ def main():
             count_pocket_errors += 1
             filtered_data = filtered_data.drop(index)
             entry['violation'] = 'Unloadable pocket'
-            discarded_structures = discarded_structures.append(entry, ignore_index=True)
+            discarded_structures.append(entry)
             continue
 
         # ===================== FILTER PHOSPHATES AND RIBOSES ===================================
@@ -117,7 +115,7 @@ def main():
             filtered_data = filtered_data.drop(index)
             count_substrates += 1
             entry['violation'] = 'Contains phosphate'
-            discarded_structures = discarded_structures.append(entry, ignore_index=True)
+            discarded_structures.append(entry)
             continue
 
         # discard ligands containing riboses
@@ -126,7 +124,7 @@ def main():
             filtered_data = filtered_data.drop(index)
             count_substrates += 1
             entry['violation'] = 'Contains ribose'
-            discarded_structures = discarded_structures.append(entry, ignore_index=True)
+            discarded_structures.append(entry)
             continue
 
         # =================== FILTER MULTIPLE LIGANDS PER STRUCTURE ==============================
@@ -142,7 +140,7 @@ def main():
                 filtered_data = filtered_data.drop(index)
                 count_multi_ligands += 1
                 entry['violation'] = 'Multiple ligands present'
-                discarded_structures = discarded_structures.append(entry, ignore_index=True)
+                discarded_structures.append(entry)
                 continue
 
         # ============================ FILTER COVALENT LIGANDS ===================================
@@ -153,7 +151,7 @@ def main():
             filtered_data = filtered_data.drop(index)
             count_covalent += 1
             entry['violation'] = 'Covalent ligand'
-            discarded_structures = discarded_structures.append(entry, ignore_index=True)
+            discarded_structures.append(entry)
             continue
 
 
@@ -165,6 +163,7 @@ def main():
     folderName = Path(args.fragmentlibrary) / 'discarded_ligands'
     if not folderName.exists():
         Path.mkdir(folderName)
+    discarded_structures = pd.DataFrame(discarded_structures).reset_index(drop=True)
     discarded_structures.to_csv(folderName / 'preprocessing.csv')
 
     # output statistics

--- a/kinase_focused_fragment_library/recombination/cli.py
+++ b/kinase_focused_fragment_library/recombination/cli.py
@@ -86,8 +86,12 @@ def main():
 
         file = folder / (subpocket + '.sdf')
 
-        # read molecules, keep hydrogen atoms
-        suppl = Chem.SDMolSupplier(str(file), removeHs=False)
+        try:
+            # read molecules, keep hydrogen atoms
+            suppl = Chem.SDMolSupplier(str(file), removeHs=False)
+        except OSError:
+            print(f"Subpocket {subpocket} not available.")
+            continue
         mols = [f for f in suppl][:args.n_frags]
 
         fragments = []


### PR DESCRIPTION
## Description
Update code base to fix deprecations or add enhancements addressing 
- run fragmentation and recombination based on the latest KLIFS dataset 
  - https://github.com/volkamerlab/KinFragLib/issues/52
- run fragmentation and recombination based on a subset of fragments (including empty subpockets) 
  - https://github.com/volkamerlab/KinFragLib/issues/47
  - https://github.com/volkamerlab/KinFragLib/issues/50

## Todos
  - [x] Fix deprecated `pandas` usage (`append` method)
  - [x] Allow for empty subpocket SDF files (`OSError` try-catch)
  - [x] Continue preprocessing with the next structure in case a ligand or pocket KLIFS file cannot be read into the `rdkit`

## Status
- [x] Ready to go